### PR TITLE
Update apollo handlers

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+<PROJECT_ROOT>/node_modules/graphql
 
 [include]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix side menu bug in Safari
 - Update MenuItem component
+- Change Apollo handlers: `afterware` handles successful responses and `onError` handles errors.
 
 ## [6.2.0] - 2019-11-19
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Example:
 window.tarantool_enterprise_core.apiMethods.axiosWizard(axiosInstance)
 ```
 
-### window.tarantool_enterprise_core.apiMethods.registerApolloHandler(eventType: 'middleware' | 'afterware', handler: (any, Array<handlers>))
+### window.tarantool_enterprise_core.apiMethods.registerApolloHandler(eventType: 'middleware' | 'onError' | 'afterware', handler: (any, Array<handlers>))
 
 Register handler for Apollo. Handler should looks like it:
 
@@ -221,7 +221,11 @@ Register handler for Apollo. Handler should looks like it:
 (r, next) => next(r + 1)
 ```
 
-It's handle middleware before query and afterware on error.
+* `middleware` runs before query;
+
+* `afterware` handles successful responses;
+
+* `onError` handles errors.
 
 More information here: [https://www.apollographql.com/docs/react/networking/network-layer/]
 


### PR DESCRIPTION
Change Apollo handlers: `afterware` handles successful responses and `onError` handles errors.