### PR TITLE
Test core API & some cross-module interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Filter out pages.
 
 ### window.tarantool_enterprise_core.pageFilter.filterPage(MenuItemType):  boolean
 
-Is page pass filters
+Does page pass filters
 
 ### Core events
 

--- a/src/core.js
+++ b/src/core.js
@@ -87,6 +87,10 @@ export default class Core {
     this.header = null
     this.pageFilter = pageFilter(this)
   }
+
+  /**
+   * @deprecated since v6.5.x (april 2020)
+   */
   setHeaderComponent(headerComponent: any) {
     this.header = headerComponent
     this.dispatch('setHeaderComponent')
@@ -117,6 +121,10 @@ export default class Core {
     namespace: string,
     menu: menuShape,
     RootComponent: ComponentType<any>,
+    /**
+     * @TODO remove "engine". Engines are deprecated since v6.5.x (april 2020),
+     * we desided to use only React
+     */
     engine: engines = 'react',
     menuMiddleware?: Object => void,
     menuFilter?: MenuItemType => boolean
@@ -136,6 +144,10 @@ export default class Core {
     }
     this.fetchEnginesAndNotify()
   }
+
+  /**
+   * @deprecated since v6.5.x (april 2020). "Engines" are deprecated
+   */
   async fetchEnginesAndNotify() {
     const currentEngines = R.uniq(this.modules.map(x => x.engine))
     let needLoad = false
@@ -164,6 +176,9 @@ export default class Core {
   getModules() {
     return this.modules
   }
+  /**
+   * @return Unsubscribe function
+   */
   subscribe(eventType: string, callback: Function) {
     if (!this.notifiers[eventType]) {
       this.notifiers[eventType] = []

--- a/src/core.js
+++ b/src/core.js
@@ -18,7 +18,7 @@ export type MenuItemType = {|
   items?: Array<MenuItemType>
 |}
 
-type halfMenuItem = {|
+export type halfMenuItem = {|
   label: string,
   path: string,
   icon?: string | Object
@@ -33,8 +33,7 @@ export type FSA = {
 
 type menuShape = ((action: FSA, state: [MenuItemType]) => (Array<MenuItemType> | Array<halfMenuItem>)) | Array<MenuItemType>
 
-
-const refineMenuItem = (item: MenuItemType | halfMenuItem): MenuItemType => ({
+export const refineMenuItem = (item: MenuItemType | halfMenuItem): MenuItemType => ({
   selected: false,
   expanded: false,
   loading: false,

--- a/src/core.js
+++ b/src/core.js
@@ -31,7 +31,8 @@ export type FSA = {
   meta?: any
 }
 
-type menuShape = (action: FSA, state: [MenuItemType]) => Array<MenuItemType> | Array<MenuItemType> | Array<halfMenuItem>
+type menuShape = ((action: FSA, state: [MenuItemType]) => (Array<MenuItemType> | Array<halfMenuItem>)) | Array<MenuItemType>
+
 
 const refineMenuItem = (item: MenuItemType | halfMenuItem): MenuItemType => ({
   selected: false,
@@ -119,7 +120,7 @@ export default class Core {
   }
   register(
     namespace: string,
-    menu: menuShape,
+    menu: menuShape | Array<halfMenuItem>,
     RootComponent: ComponentType<any>,
     /**
      * @TODO remove "engine". Engines are deprecated since v6.5.x (april 2020),
@@ -129,7 +130,7 @@ export default class Core {
     menuMiddleware?: Object => void,
     menuFilter?: MenuItemType => boolean
   ) {
-    const addingModule = {
+    const addingModule: CoreModule = {
       namespace,
       menu: Array.isArray(menu) ? menu.map(refineMenuItem) : menu,
       menuMiddleware,

--- a/src/core.js
+++ b/src/core.js
@@ -31,7 +31,8 @@ export type FSA = {
   meta?: any
 }
 
-type menuShape = ((action: FSA, state: [MenuItemType]) => (Array<MenuItemType> | Array<halfMenuItem>)) | Array<MenuItemType>
+type menuShape = ((action: FSA, state: [MenuItemType]) => (Array<MenuItemType> | Array<halfMenuItem>))
+  | Array<MenuItemType>
 
 export const refineMenuItem = (item: MenuItemType | halfMenuItem): MenuItemType => ({
   selected: false,

--- a/src/core.menu-tests.test.js
+++ b/src/core.menu-tests.test.js
@@ -1,0 +1,68 @@
+// @flow
+import { selectCurrentMenuItemLabel } from './store/selectors'
+import { generateCoreWithStore, genModuleWithNamespace, registerModule } from './test-utils/coreInstance'
+import {
+  refineMenuItem,
+  type MenuItemType,
+  type halfMenuItem,
+  type FSA,
+  type CoreModule,
+} from './core'
+
+
+const RootComponent = () => '';
+
+const genModuleWithFilter = (() => {
+  let namespaceId = 0;
+  return (menu: halfMenuItem[], menuFilter): CoreModule => ({
+    namespace: `namespace-${namespaceId++}`,
+    menu: menu.map(refineMenuItem),
+    RootComponent,
+    engine: 'react',
+    menuMiddleware: () => { },
+    menuFilter,
+  });
+})();
+
+describe('page filter multi-module', () => {
+  const { coreInstance: core, store } = generateCoreWithStore();
+  const pageToHide: halfMenuItem = {
+    path: '/test',
+    label: 'Page to hide',
+  };
+  const visiblePage = {
+    path: '/other-page',
+    label: 'Other page'
+  };
+
+  const hidingModule = genModuleWithFilter(
+    [
+      pageToHide,
+    ],
+    (menuItem) => menuItem.path !== pageToHide.path
+  );
+
+  const showingModule = genModuleWithFilter(
+    [
+      pageToHide,
+      visiblePage,
+    ],
+    (menuItem) => true
+  );
+
+
+  registerModule(core, showingModule);
+
+  it('page should be VISIBLE when only "permissive" filters', () => {
+    expect(core.pageFilter.filterPage(pageToHide)).toBe(true)
+  });
+
+  it('one module\'s page should be HIDDEN because of OTHER MODULE\'S filter', () => {
+    registerModule(core, hidingModule);
+    expect(core.pageFilter.filterPage(pageToHide)).toBe(false);
+
+    //not-filtered page should remain VISIBLE
+    expect(core.pageFilter.filterPage(visiblePage)).toBe(true);
+  });
+
+});

--- a/src/core.menu-tests.test.js
+++ b/src/core.menu-tests.test.js
@@ -1,14 +1,10 @@
 // @flow
-import { selectCurrentMenuItemLabel } from './store/selectors'
-import { generateCoreWithStore, genModuleWithNamespace, registerModule } from './test-utils/coreInstance'
+import { generateCoreWithStore, registerModule } from './test-utils/coreInstance'
 import {
   refineMenuItem,
-  type MenuItemType,
   type halfMenuItem,
-  type FSA,
-  type CoreModule,
+  type CoreModule
 } from './core'
-
 
 const RootComponent = () => '';
 
@@ -20,15 +16,15 @@ const genModuleWithFilter = (() => {
     RootComponent,
     engine: 'react',
     menuMiddleware: () => { },
-    menuFilter,
+    menuFilter
   });
 })();
 
 describe('page filter multi-module', () => {
-  const { coreInstance: core, store } = generateCoreWithStore();
+  const { coreInstance: core } = generateCoreWithStore();
   const pageToHide: halfMenuItem = {
     path: '/test',
-    label: 'Page to hide',
+    label: 'Page to hide'
   };
   const visiblePage = {
     path: '/other-page',
@@ -37,7 +33,7 @@ describe('page filter multi-module', () => {
 
   const hidingModule = genModuleWithFilter(
     [
-      pageToHide,
+      pageToHide
     ],
     (menuItem) => menuItem.path !== pageToHide.path
   );
@@ -45,11 +41,10 @@ describe('page filter multi-module', () => {
   const showingModule = genModuleWithFilter(
     [
       pageToHide,
-      visiblePage,
+      visiblePage
     ],
     (menuItem) => true
   );
-
 
   registerModule(core, showingModule);
 
@@ -61,8 +56,7 @@ describe('page filter multi-module', () => {
     registerModule(core, hidingModule);
     expect(core.pageFilter.filterPage(pageToHide)).toBe(false);
 
-    //not-filtered page should remain VISIBLE
+    // not-filtered page should remain VISIBLE
     expect(core.pageFilter.filterPage(visiblePage)).toBe(true);
   });
-
 });

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -19,11 +19,11 @@ import { didPromiseResolve } from './test-utils/promise'
 // }
 // Core.analyticModule
 
-const Root = () => '';
+const RootComponent = () => '';
 const genModuleWithNamespace = (namespace): CoreModule => ({
   namespace,
-  menu: ([]: any),
-  RootComponent: Root,
+  menu: [],
+  RootComponent,
   engine: 'react',
 });
 

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -1,18 +1,11 @@
 // @flow
-import { selectCurrentMenuItemLabel } from './store/selectors'
-import store from './store/index'
-import core from './coreInstance'
-// - - -
-
 import Core, {
   type MenuItemType,
   type FSA,
   type CoreModule,
 } from './core'
-
-// global import
-const React = window.react;
-const ReactDom = window.reactDom;
+import { registerModule } from './test-utils/coreInstance'
+import { didPromiseResolve } from './test-utils/promise'
 
 
 // Core.activeEngines: { [name: engines]: moduleStatus }
@@ -26,33 +19,13 @@ const ReactDom = window.reactDom;
 // }
 // Core.analyticModule
 
-const didPromiseResolve = async (promiseToTest, timeout = 0) => {
-  let didResolve = false;
-  promiseToTest.then(() => didResolve = true);
-
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve(didResolve);
-    }, timeout)
-  });
-};
-
-const Root = () => <div></div>;
+const Root = () => '';
 const genModuleWithNamespace = (namespace): CoreModule => ({
   namespace,
   menu: ([]: any),
   RootComponent: Root,
   engine: 'react',
 });
-const registerModule = (core, module) => core.register(
-  module.namespace,
-  module.menu,
-  module.RootComponent,
-  module.engine,
-  module.menuMiddleware,
-  module.menuFilter
-);
-
 
 describe('checkNamespaces()', () => {
   const core = new Core();

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -1,0 +1,118 @@
+// @flow
+import { selectCurrentMenuItemLabel } from './store/selectors'
+import store from './store/index'
+import core from './coreInstance'
+// - - -
+
+import Core, {
+  type MenuItemType,
+  type FSA,
+  type CoreModule,
+} from './core'
+
+// global import
+const React = window.react;
+const ReactDom = window.reactDom;
+
+
+// Core.activeEngines: { [name: engines]: moduleStatus }
+// Core.apiMethods = {
+//   apolloLinkAfterware,
+//   apolloLinkMiddleware,
+//   apolloLinkOnError,
+//   axiosWizard,
+//   registerApolloHandler,
+//   registerAxiosHandler,
+// }
+// Core.analyticModule
+
+const Root = () => <div></div>;
+const genModuleWithNamespace = (namespace): CoreModule => ({
+  namespace,
+  menu: ([]: any),
+  RootComponent: Root,
+  engine: 'react',
+});
+const registerModule = (core, module) => core.register(
+  module.namespace,
+  module.menu,
+  module.RootComponent,
+  module.engine,
+  module.menuMiddleware,
+  module.menuFilter
+);
+
+
+describe('checkNamespaces()', () => {
+  const core = new Core();
+
+  const module = genModuleWithNamespace('some-namespace');
+
+  registerModule(core, module);
+  
+  it('should reject module with used namespace', () => {
+    const moduleWithSameNamespace = genModuleWithNamespace(module.namespace);
+    expect(() => core.checkNamespace(moduleWithSameNamespace)).toThrow();
+  });
+
+  it('should accept module with other (used for the first time) namespace', () => {
+    const otherModule = genModuleWithNamespace('other-namespace');
+    expect(() => core.checkNamespace(otherModule)).not.toThrow();
+  });
+});
+
+
+describe('register()', () => {
+  const core = new Core();
+
+  const module = genModuleWithNamespace('some-namespace');
+
+  registerModule(core, module);
+  
+  it('should reject module with used namespace', () => {
+    const moduleWithSameNamespace = genModuleWithNamespace(module.namespace);
+    expect(() => registerModule(core, moduleWithSameNamespace)).toThrow();
+  });
+
+  it('should accept module with other (used for the first time) namespace', () => {
+    const otherModule = genModuleWithNamespace('other-namespace');
+    expect(() => registerModule(core, otherModule)).not.toThrow();
+  });
+});
+
+
+// Core.components = {}
+// Core.constructor()
+
+// Core.dispatch(eventType: string, event: ?Object = null) {}
+
+// // async
+// Core.fetchEnginesAndNotify() {}
+
+// Core.getHeaderComponent() {}
+// Core.getModules() {}
+
+// Core.header
+// Core.history
+
+// Core.logo
+
+// Core.modules
+
+// Core.notifiers: { [string]: Array<Function> }
+// Core.notify()
+
+// Core.pageFilter = {
+//   registerFilter,
+//   getFilters,
+//   applyFilters,
+//   filterPage
+// }
+
+// Core.register() {}
+
+// Core.setHeaderComponent(headerComponent: any) {}
+// Core.subscribe(eventType: string, callback: Function) {}
+
+// Core.waitForModule(namespace: string): Promise < boolean > {}  
+

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -87,6 +87,17 @@ describe('register()', () => {
     const otherModule = genModuleWithNamespace('other-namespace');
     expect(() => registerModule(core, otherModule)).not.toThrow();
   });
+
+  it('should dispatch "registerModule" event on module register', () => {
+    const fnRegister = jest.fn()
+    core.subscribe('registerModule', fnRegister)
+
+    registerModule(core, genModuleWithNamespace('namespace-1'));
+    expect(fnRegister).toBeCalledTimes(1)
+
+    registerModule(core, genModuleWithNamespace('namespace-2'));
+    expect(fnRegister).toBeCalledTimes(2);
+  });
 });
 
 

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -1,30 +1,16 @@
 // @flow
 import Core, {
-  type MenuItemType,
-  type FSA,
-  type CoreModule,
+  type CoreModule
 } from './core'
 import { registerModule } from './test-utils/coreInstance'
 import { didPromiseResolve } from './test-utils/promise'
-
-
-// Core.activeEngines: { [name: engines]: moduleStatus }
-// Core.apiMethods = {
-//   apolloLinkAfterware,
-//   apolloLinkMiddleware,
-//   apolloLinkOnError,
-//   axiosWizard,
-//   registerApolloHandler,
-//   registerAxiosHandler,
-// }
-// Core.analyticModule
 
 const RootComponent = () => '';
 const genModuleWithNamespace = (namespace): CoreModule => ({
   namespace,
   menu: [],
   RootComponent,
-  engine: 'react',
+  engine: 'react'
 });
 
 describe('checkNamespaces()', () => {
@@ -43,7 +29,6 @@ describe('checkNamespaces()', () => {
     expect(() => core.checkNamespace(otherModule)).not.toThrow();
   });
 });
-
 
 describe('register()', () => {
   const core = new Core();
@@ -72,38 +57,6 @@ describe('register()', () => {
     expect(fnRegister).toBeCalledTimes(2);
   });
 });
-
-
-// Core.components = {}
-// Core.constructor()
-
-// Core.dispatch(eventType: string, event: ?Object = null) {}
-
-// // async
-// Core.fetchEnginesAndNotify() {}
-
-// Core.getHeaderComponent() {}
-// Core.getModules() {}
-
-// Core.header
-// Core.history
-
-// Core.logo
-
-// Core.modules
-
-// Core.notifiers: { [string]: Array<Function> }
-// Core.notify()
-
-// Core.pageFilter = {
-//   registerFilter,
-//   getFilters,
-//   applyFilters,
-//   filterPage
-// }
-
-// Core.setHeaderComponent(headerComponent: any) {}
-
 
 describe('subscribe() and dispatch()', () => {
   it('should pass dispatched data to subscribed callback', () => {
@@ -136,9 +89,7 @@ describe('subscribe() and dispatch()', () => {
     expect(handlerForDispatchedEvent).toBeCalled();
     expect(handlerForOtherEvent).not.toBeCalled();
   });
-
 });
-
 
 describe('waitForModule()', () => {
   const module = genModuleWithNamespace('some-namespace');
@@ -162,5 +113,4 @@ describe('waitForModule()', () => {
       return expect(didPromiseResolve(waitPromise)).resolves.toBe(false);
     }
   );
-
 });

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -118,10 +118,42 @@ describe('register()', () => {
 //   filterPage
 // }
 
-// Core.register() {}
-
 // Core.setHeaderComponent(headerComponent: any) {}
-// Core.subscribe(eventType: string, callback: Function) {}
+
+
+describe('subscribe() and dispatch()', () => {
+  it('should pass dispatched data to subscribed callback', () => {
+    const core = new Core();
+    const eventType = 'some-event';
+    const eventData1 = {};
+    const eventData2 = {};
+
+    const handler = jest.fn();
+    core.subscribe(eventType, handler);
+
+    core.dispatch(eventType, eventData1);
+    expect(handler.mock.calls[0][0]).toBe(eventData1);
+
+    core.dispatch(eventType, eventData2);
+    expect(handler.mock.calls[1][0]).toBe(eventData2);
+  });
+
+  it('should NOT call listerens of other events', () => {
+    const core = new Core();
+    const eventTypeDispatched = 'some-event';
+    const eventTypeOther = 'other-event';
+
+    const handlerForDispatchedEvent = jest.fn();
+    const handlerForOtherEvent = jest.fn();
+    core.subscribe(eventTypeDispatched, handlerForDispatchedEvent);
+    core.subscribe(eventTypeOther, handlerForOtherEvent);
+
+    core.dispatch(eventTypeDispatched);
+    expect(handlerForDispatchedEvent).toBeCalled();
+    expect(handlerForOtherEvent).not.toBeCalled();
+  });
+
+});
 
 
 describe('waitForModule()', () => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux'
-import menuReducer, { type MenuState } from './reducers/menu'
+import { generateInstance as generateMenuReducerInstance, type MenuState } from './reducers/menu'
 import notificationsReducer, { type NotificationState } from './reducers/notifications'
 import uiReducer from './reducers/ui'
 import { changeTitleMiddleware } from './middlewares/title'
@@ -35,6 +35,7 @@ export type State = {
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 
 export const createCoreStore = (core: Core) => {
+  const menuReducer = generateMenuReducerInstance();
   const store = createStore(
     connectRouter(core.history)(
       combineReducers({

--- a/src/test-utils/coreInstance.js
+++ b/src/test-utils/coreInstance.js
@@ -9,3 +9,12 @@ export const generateCoreWithStore = () => {
     store
   }
 }
+
+export const registerModule = (core, module) => core.register(
+  module.namespace,
+  module.menu,
+  module.RootComponent,
+  module.engine,
+  module.menuMiddleware,
+  module.menuFilter
+);

--- a/src/test-utils/promise.js
+++ b/src/test-utils/promise.js
@@ -1,7 +1,9 @@
 
-export const didPromiseResolve = async (promiseToTest, timeout = 0) => {
+export const didPromiseResolve = async(promiseToTest, timeout = 0) => {
   let didResolve = false;
-  promiseToTest.then(() => didResolve = true);
+  promiseToTest.then(() => {
+    didResolve = true;
+  });
 
   return new Promise(resolve => {
     setTimeout(() => {

--- a/src/test-utils/promise.js
+++ b/src/test-utils/promise.js
@@ -1,0 +1,11 @@
+
+export const didPromiseResolve = async (promiseToTest, timeout = 0) => {
+  let didResolve = false;
+  promiseToTest.then(() => didResolve = true);
+
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(didResolve);
+    }, timeout)
+  });
+};


### PR DESCRIPTION
Added tests for core api methods and page filtering, 

including some tests for cross-module interaction:
- filters from one module apply to other module's pages
- filters race: "premissive" filters don't cancel "restrictive" filters

This edits also:
- deprecate .setHeaderComponent() and "engines" (only "React" engine should be used)
- change (fix) flow-type of `CoreModule.menu` (module `menu` field and menu param in `register()` method)

As part of #76


-----

Test coverage of core.js
actual:
<img width="746" alt="изображение" src="https://user-images.githubusercontent.com/7147989/80459594-3eecbf00-893b-11ea-8e9a-a386dbdd6376.png">

without deprecated methods:
<img width="746" alt="изображение" src="https://user-images.githubusercontent.com/7147989/80459999-deaa4d00-893b-11ea-884c-75d8f31a81c7.png">