### PR TITLE
Release 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.0.0]
+
 - Register in DOM only in Lua part, remove it from npm module part. You should use install method.
 - Remove nanoid package because of weird webpack build
 - Remove engine code from Core (but save as args for compatibility)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tarantool.io/frontend-core",
-  "version": "6.5.1",
+  "version": "7.0.0",
   "main": "compiled_module/core.js",
   "repository": {
     "type": "git",

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -1,12 +1,12 @@
 // @flow
 import Core, {
-  type CoreModule
+  type InputCoreModule
 } from './core'
 import { registerModule } from './test-utils/coreInstance'
 import { didPromiseResolve } from './test-utils/promise'
 
 const RootComponent = () => '';
-const genModuleWithNamespace = (namespace): CoreModule => ({
+const genModuleWithNamespace = (namespace): InputCoreModule => ({
   namespace,
   menu: [],
   RootComponent,


### PR DESCRIPTION
- Register in DOM only in Lua part, remove it from npm module part. You should use install method.
- Remove nanoid package because of weird webpack build
- Remove engine code from Core (but save as args for compatibility)
- Add registerModule method and deprecate method register