### PR TITLE
Update rocks publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,8 @@ jobs:
       # Make a release
       - run: echo TAG=${GITHUB_REF##*/} >> $GITHUB_ENV
       - run: tarantoolctl rocks new_version --tag ${{ env.TAG }}
-      - run: tarantoolctl rocks make frontend-core-${{ env.TAG }}-1.rockspec
+      - run: sed -i '/branch = "master"/d' frontend-core-${{ env.TAG }}-1.rockspec
+      - run: tarantoolctl rocks install frontend-core-${{ env.TAG }}-1.rockspec
       - run: tarantoolctl rocks pack frontend-core ${{ env.TAG }}
 
       - uses: tarantool/rocks.tarantool.org/github-action@master


### PR DESCRIPTION
- Call `rocks install` instead of `rocks make` for cleanliness.
- Remove branch master from release rockspec.