### PR TITLE
ci: use ubuntu-20.04 instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-18.04]
+        runs-on: [ubuntu-20.04]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The ubuntu-18.04 environment is deprecated. For more details see [1].

[1] https://github.com/actions/virtual-environments/issues/6002